### PR TITLE
Fixed `require` form in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/ndwarshuis/om.el
 Then require in your emacs config:
 
 ```
-(require 'om.el)
+(require 'om)
 ```
 
 # Motivation


### PR DESCRIPTION
The `require` function takes a symbol `FEATURE`. Since the library invokes `(provide 'om)`, that symbol `om` should be used instead.

[Yeah, I realize you know that. I assume this is just a typo in the README.md, which is what I changed.]