### PR TITLE
Fix package URL in commentary and typos in README and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ to be a child depending on the type. There are three of these restrictions:
 - Branch elements with child objects (aka 'object containers'): these are
   element types that hold textual information (eg paragraph)
 - Branch objects with child objects (aka 'recursive objects'): these are object
-  types used primarily for text formating (bold, italic, underline, etc)
+  types used primarily for text formatting (bold, italic, underline, etc)
 
 Note: it is never allowed for an element type to be a child of a branch object
 type.
@@ -97,12 +97,12 @@ This package takes several deviations from the original terminology found in
 - 'branch' is used here instead of 'container'. Furthermore, 'leaf' is used to
   describe the converse of 'branch' (there does not seem to be an equivalent
   term in `org-element.el`)
-- `org-element.el` uses 'attribute(s)' and 'property(ies)' interchangably to
+- `org-element.el` uses 'attribute(s)' and 'property(ies)' interchangeably to
   describe nodes; here only 'property(ies)' is used
 
 ## Properties
 
-All properies specified by `org-element.el` are readable by this API (eg one can
+All properties specified by `org-element.el` are readable by this API (eg one can
 query them with functions like `om-get-property`).
 
 The properties `:begin`, `:end`, `:contents-begin`, `:contents-end`, `:parent`,
@@ -2151,7 +2151,7 @@ The following properties are settable:
 Return copy of **`node`**, which may be a circular tree.
 
 This is only necessary to copy nodes parsed using any of parsing
-functions from this this package (example, `org-ml-parse-this-headline`)
+functions from this package (for example, `org-ml-parse-this-headline`)
 because these retain parent references which makes the node a circular
 list. None of the builder functions add parent references, so
 `copy-tree` will be a faster alternative to this function.
@@ -4479,7 +4479,7 @@ keyword given by **`key`**. The format for each keyword is given below:
 - `caption`[``string1``] ``string2``: `((string2 . string1) ...)`
     where ``string1`` may be nil and multiple list members
     correspond to multiple caption entries
-- `headers` ``string``: `(string ...)` where mulitple list members
+- `headers` ``string``: `(string ...)` where multiple list members
     correspond to multiple headers entries
 - `caption`[``string``] ``secstring``: `((string . secstring) ...)`
     where ``string`` may be nil and multiple list members

--- a/org-ml.el
+++ b/org-ml.el
@@ -245,7 +245,7 @@ length of LIST is equal to LENGTH initially."
   (-slice plist 1 nil 2))
 
 (defun org-ml--plist-map-values (fun plist)
-  "Map FUN over over the values in PLIST.
+  "Map FUN over the values in PLIST.
 FUN is a unary function that returns a modified value."
   (let ((keys (org-ml--plist-get-keys plist)))
     (->> (org-ml--plist-get-vals plist)
@@ -1173,8 +1173,7 @@ bounds."
 
 (defun org-ml--get-property-attribute (attribute type prop)
   "Return ATTRIBUTE for PROP of node TYPE.
-If NOERROR is non-nil, return nil instead of signaling an error
-if PROP in TYPE does not have ATTRIBUTE."
+Signal an error if PROP in TYPE does not have ATTRIBUTE."
   (-if-let (type-list (alist-get type org-ml--property-alist))
       (if (assoc prop type-list)
           (-when-let (plist (alist-get prop type-list))
@@ -1251,7 +1250,7 @@ and ILLEGAL types were attempted to be set."
 
 (defun org-ml--build-bare-node (type post-blank)
   "Return a new node assembled from TYPE with POST-BLANK.
-TYPE is a symbol and POST-BLANK is a postive integer."
+TYPE is a symbol and POST-BLANK is a positive integer."
   `(,type (:post-blank ,(or post-blank 0))))
 
 (defun org-ml--build-leaf-node (type post-blank)
@@ -1852,7 +1851,7 @@ performed. TABLE is used to get the table width."
   "Return copy of NODE, which may be a circular tree.
 
 This is only necessary to copy nodes parsed using any of parsing
-functions from this this package (example, `org-ml-parse-this-headline')
+functions from this package (for example, `org-ml-parse-this-headline')
 because these retain parent references which makes the node a circular
 list. None of the builder functions add parent references, so
 `copy-tree' will be a faster alternative to this function."
@@ -2942,7 +2941,7 @@ keyword given by KEY. The format for each keyword is given below:
 - CAPTION[`STRING1'] `STRING2': ((STRING2 . STRING1) ...)
   where `STRING1' may be nil and multiple list members
   correspond to multiple caption entries
-- HEADERS `STRING': (STRING ...) where mulitple list members
+- HEADERS `STRING': (STRING ...) where multiple list members
   correspond to multiple headers entries
 - CAPTION[`STRING'] `SECSTRING': ((STRING . SECSTRING) ...)
   where `STRING' may be nil and multiple list members
@@ -3482,7 +3481,7 @@ subheadlines will not be counted)."
 
 ;;; plain-list
 
-;; TODO there seems to be a bug in the interpeter that prevents "+" bullets from
+;; TODO there seems to be a bug in the interpreter that prevents "+" bullets from
 ;; being recognized (as of org-9.1.9 they are simply read as "-")
 (defun org-ml-plain-list-set-type (type plain-list)
   "Return PLAIN-LIST node with type property set to TYPE.

--- a/org-ml.el
+++ b/org-ml.el
@@ -4,7 +4,7 @@
 
 ;; Author: Nathan Dwarshuis <ndwar@yavin4.ch>
 ;; Keywords: org-mode, outlines
-;; Homepage: https://github.com/ndwarshuis/org-ml.el
+;; Homepage: https://github.com/ndwarshuis/org-ml
 ;; Package-Requires: ((emacs "26.1") (dash "2.15") (s "1.12"))
 ;; Version: 2.0.1
 
@@ -44,7 +44,7 @@
 ;; - writers: insert/update the contents of a buffer given a parse tree
 
 ;; For examples please see full documentation at:
-;; https://github.com/ndwarshuis/org-ml.el
+;; https://github.com/ndwarshuis/org-ml
 
 ;;; Code:
 


### PR DESCRIPTION
#### Fix package URL in commentary

* `org-ml.el`: Fix package URL in commentary.


#### Fix various typos in README and docstrings

* `README.md`: Fix typos: "formating", "interchangably", "properies", doubled "this", and "mulitple".
* `org-ml.el` (`org-ml--plist-map-values`): Delete doubled "over" in docstring.
(`org-ml--get-property-attribute`): Delete reference to nonexistent `NOERROR` argument in docstring.
(`org-ml--build-bare-node`): Fix typo in docstring: "postive".
(`org-ml-clone-node`): Delete doubled "this" in docstring.
(`org-ml-set-affiliated-keyword`): Fix typo in docstring: "mulitple".
(`org-ml-plain-list-set-type`): Fix typo in comment: "interpeter".