### PR TITLE
Fix org-ml-build-property-drawer! key/val args

### DIFF
--- a/dev/org-ml-examples.el
+++ b/dev/org-ml-examples.el
@@ -968,7 +968,7 @@
       => "CLOSED: [2019-01-01 Tue +1m -1d]")
 
     (defexamples org-ml-build-property-drawer!
-      (->> (org-ml-build-property-drawer! '(key val))
+      (->> (org-ml-build-property-drawer! '("key" "val"))
            (org-ml-to-trimmed-string))
       => (:result ":PROPERTIES:"
                   ":key:      val"
@@ -985,7 +985,7 @@
       (->> (org-ml-build-headline!
             :title-text "really impressive title"
             :section-children
-            (list (org-ml-build-property-drawer! '(key val))
+            (list (org-ml-build-property-drawer! '("key" "val"))
                   (org-ml-build-paragraph! "section text"))
             (org-ml-build-headline! :title-text "subhead"))
            (org-ml-to-trimmed-string))

--- a/dev/org-ml-test-internal.el
+++ b/dev/org-ml-test-internal.el
@@ -329,7 +329,7 @@ is the converse."
       (org-ml-build-section (org-ml-build-paragraph! "*sec")) "*sec")
     (org-ml--test-from-string nil
       (org-ml-build-property-drawer) ":PROPERTIES:\n:END:"
-      (org-ml-build-property-drawer! '(KEY val)) ":PROPERTIES:\n:KEY: val\n:END:")
+      (org-ml-build-property-drawer! '("KEY" "val")) ":PROPERTIES:\n:KEY: val\n:END:")
     (org-ml--test-from-string nil
       (org-ml-build-quote-block) "#+begin_quote\n#+end_quote"
       (org-ml-build-quote-block (org-ml-build-paragraph! "p")) "#+begin_quote\np\n#+end_quote")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2351,7 +2351,7 @@ are both strings, where each list will generate a node-property
 node in the property-drawer node like `":key: val"`.
 
 ```el
-(->> (org-ml-build-property-drawer! '(key val))
+(->> (org-ml-build-property-drawer! '("key" "val"))
   (org-ml-to-trimmed-string))
  ;; => ":PROPERTIES:
  ;      :key:      val
@@ -2393,7 +2393,7 @@ All arguments not mentioned here follow the same rules as
   (org-ml-to-trimmed-string))
  ;; => "* really impressive title [0/9000]"
 
-(->> (org-ml-build-headline! :title-text "really impressive title" :section-children (list (org-ml-build-property-drawer! '(key val))
+(->> (org-ml-build-headline! :title-text "really impressive title" :section-children (list (org-ml-build-property-drawer! '("key" "val"))
 											   (org-ml-build-paragraph! "section text"))
 			      (org-ml-build-headline! :title-text "subhead"))
   (org-ml-to-trimmed-string))

--- a/org-ml.el
+++ b/org-ml.el
@@ -2231,8 +2231,8 @@ Each member in KEYVALS is a list like (KEY VAL) where KEY and VAL
 are both strings, where each list will generate a node-property
 node in the property-drawer node like \":key: val\"."
   (->> keyvals
-       (org-ml--map* (let ((key (symbol-name (car it)))
-                           (val (symbol-name (cadr it))))
+       (org-ml--map* (let ((key (car it))
+                           (val (cadr it)))
                        (org-ml-build-node-property key val)))
        (apply #'org-ml-build-property-drawer :post-blank post-blank)))
 


### PR DESCRIPTION
This patch modifies org-ml-build-property-drawer! so that key/val args
are passed as strings as opposed to symbols. This brings the function
into conformance with the existing documentation.